### PR TITLE
(SPARK-38862) - allow conf to expose SparkSubmissionServer while making use of spark.authentication elsewhere

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -166,8 +166,8 @@ private[deploy] class Master(
     val authKey = SecurityManager.SPARK_AUTH_SECRET_CONF
     require(conf.getOption(authKey).isEmpty || canUseAuthKeyWithServerConf,
       s"The RestSubmissionServer does not support authentication via ${authKey}.  Either turn " +
-        "off the RestSubmissionServer with spark.master.rest.enabled=false, or do not use " +
-        "authentication.")
+        "off the RestSubmissionServer with spark.master.rest.enabled=false, or explicitly specify a setting " +
+        "to use fot the RestSubmissionServer, such as mode \"SecureGateway\"".")
   }
 
   override def onStart(): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -167,7 +167,7 @@ private[deploy] class Master(
     require(conf.getOption(authKey).isEmpty || canUseAuthKeyWithServerConf,
       s"The RestSubmissionServer does not support authentication via ${authKey}.  Either turn " +
         "off the RestSubmissionServer with spark.master.rest.enabled=false, or explicitly specify a setting " +
-        "to use fot the RestSubmissionServer, such as mode \"SecureGateway\"".")
+        "to use for the RestSubmissionServer, such as mode \"SecureGateway\"".")
   }
 
   override def onStart(): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -116,28 +116,6 @@ private[deploy] class Master(
 
   private val spreadOutDrivers = conf.get(SPREAD_OUT_DRIVERS)
 
-  object MasterRestAuthMode extends Enumeration {
-    val NoneOption    = "None"
-    val SecureGatewayOption = "SecureGateway"
-
-    def serverSecuredByAlternativeMethod(mode: MasterRestAuthMode): Boolean = {
-      mode match {
-        case SecureGatewayOption => true,
-        case _ => false
-      }
-    }
-
-    def fromStringOrNone(mode: String): MasterRestAuthMode = {
-      mode.toLowerCase match {
-        case MasterRestAuthMode.toLowerCase => SecureGatewayOption
-        case NoneOption.toLowerCase => NoneOption
-        case _ =>
-          logWarning(log"Specified master rest auth mode $mode was unrecognised. Defaulting to None.")
-          None
-      }
-    }
-  }
-
   // As a temporary workaround before better ways of configuring memory, we allow users to set
   // a flag that will perform round-robin scheduling across the nodes (spreading out each app
   // among all the nodes) instead of trying to consolidate each app onto a small # of nodes.
@@ -167,7 +145,7 @@ private[deploy] class Master(
     require(conf.getOption(authKey).isEmpty || canUseAuthKeyWithServerConf,
       s"The RestSubmissionServer does not support authentication via ${authKey}.  Either turn " +
         "off the RestSubmissionServer with spark.master.rest.enabled=false, or explicitly specify a setting " +
-        "to use for the RestSubmissionServer, such as mode \"SecureGateway\"".")
+        "to use for the RestSubmissionServer, such as mode \"SecureGateway\".")
   }
 
   override def onStart(): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/master/MasterRestAuthMode.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/MasterRestAuthMode.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.master
+
+private[master] object MasterRestAuthMode extends Enumeration {
+    val NoneOption = "None"
+    val SecureGatewayOption = "SecureGateway"
+
+    def serverSecuredByAlternativeMethod(mode: MasterRestAuthMode): Boolean = {
+      mode match {
+        case SecureGatewayOption => true,
+        case _ => false
+      }
+    }
+
+    def fromStringOrNone(mode: String): MasterRestAuthMode = {
+      mode.toLowerCase match {
+        case MasterRestAuthMode.toLowerCase => SecureGatewayOption
+        case NoneOption.toLowerCase => NoneOption
+        case _ =>
+          logWarning(log"Specified master rest auth mode $mode was unrecognised. Defaulting to None.")
+          None
+      }
+    }
+  }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1935,6 +1935,14 @@ package object config {
     .booleanConf
     .createWithDefault(false)
 
+  private[spark] val MASTER_REST_SERVER_AUTH_MODE = ConfigBuilder("spark.master.rest.auth.mode")
+    .doc("Specifies the authentication mechanism of the master REST services. The default value is None. " + 
+      "The value \"SecureGateway\" can be used to signify that you have provided an external mechanism of " + 
+      "providing authentication for all REST API's of the spark master servers(s).")
+    .version("3.6.0")
+    .booleanConf
+    .createWithDefault("None")
+
   private[spark] val MASTER_REST_SERVER_HOST = ConfigBuilder("spark.master.rest.host")
     .doc("Specifies the host of the Master REST API endpoint")
     .version("4.0.0")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1941,8 +1941,8 @@ package object config {
       "providing authentication for all REST API's of the spark master servers(s). This setting relates to " + 
       "spark.authenticate.*, but influences only the REST interfaces of the spark master.")
     .version("3.6.0")
-    .booleanConf
-    .createWithDefault("None")
+    .stringConf
+    .createWithDefaultString("None")
 
   private[spark] val MASTER_REST_SERVER_HOST = ConfigBuilder("spark.master.rest.host")
     .doc("Specifies the host of the Master REST API endpoint")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1938,7 +1938,8 @@ package object config {
   private[spark] val MASTER_REST_SERVER_AUTH_MODE = ConfigBuilder("spark.master.rest.auth.mode")
     .doc("Specifies the authentication mechanism of the master REST services. The default value is None. " + 
       "The value \"SecureGateway\" can be used to signify that you have provided an external mechanism of " + 
-      "providing authentication for all REST API's of the spark master servers(s).")
+      "providing authentication for all REST API's of the spark master servers(s). This setting relates to " + 
+      "spark.authenticate.*, but influences only the REST interfaces of the spark master.")
     .version("3.6.0")
     .booleanConf
     .createWithDefault("None")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1936,9 +1936,9 @@ package object config {
     .createWithDefault(false)
 
   private[spark] val MASTER_REST_SERVER_AUTH_MODE = ConfigBuilder("spark.master.rest.auth.mode")
-    .doc("Specifies the authentication mechanism of the master REST services. The default value is None. " + 
+    .doc("Specifies the authentication mechanism of the master REST services. The default value is \"None\". " + 
       "The value \"SecureGateway\" can be used to signify that you have provided an external mechanism of " + 
-      "providing authentication for all REST API's of the spark master servers(s). This setting relates to " + 
+      "providing authentication for all REST APIs of the spark master servers(s). This setting relates to " + 
       "spark.authenticate.*, but influences only the REST interfaces of the spark master.")
     .version("4.0.0")
     .stringConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1940,7 +1940,7 @@ package object config {
       "The value \"SecureGateway\" can be used to signify that you have provided an external mechanism of " + 
       "providing authentication for all REST API's of the spark master servers(s). This setting relates to " + 
       "spark.authenticate.*, but influences only the REST interfaces of the spark master.")
-    .version("3.6.0")
+    .version("4.0.0")
     .stringConf
     .createWithDefaultString("None")
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -49,9 +49,14 @@ specified below, the secret must be defined by setting the `spark.authenticate.s
 option. The same secret is shared by all Spark applications and daemons in that case, which limits
 the security of these deployments, especially on multi-tenant clusters.
 
-The REST Submission Server does not support authentication. You should
+The REST Submission Server does not natively support authentication. You should
 ensure that all network access to the REST API (port 6066 by default) 
-is restricted to hosts that are trusted to submit jobs.
+is restricted to hosts that are trusted to submit jobs, or use a proxy that provides authentication.
+
+If you plan to use a proxy to handle authentication to the REST submission server, you must configure the setting
+`spark.master.rest.auth.mode` to `"SecureGateway"`, which will enable you to continue to use the
+setting `spark.authenticate` properties for all other authentication, unless specified otherwise below. The default
+setting of this value is `"None"`, which will throw fatal errors during master startup when used in combination with `spark.authenticate`.
 
 ### YARN
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Adds a new property `spark.master.rest.auth.mode` which accepts 2 values:
* `None`: No auth mechanism is at play, this causes spark to fail (as it does today) when using properties `spark.authentication`
* `SecureGateway`: User is telling us they are covering all authentication/authorisation to the rest submission server resource.
* Unknown values will warn and default to none.

### Why are the changes needed?

As a user, in standalone spark I need to use authentication where the spark cluster itself is running in a trusted domain.  Right now, when enabling the rest submission server, there are validations (sensible ones) that prevent the user from running the configuration if I am using properties from `spark.authentication` for other facets of spark. We need a way to specify the fact that:
1. We're aware of the potential gap in our security if we are not using a secured gateway,
2. We're specifying in configuration that we've got it covered, a sys admin can quickly understand from conf what's going on here,

There are valid reasons why I feel providing authentication within the rest submission server itself would be unnecessary/limiting. I argued with myself on the Jira ticket about piggybacking `spark.authentication` props but my balanced conclusion is:

1. It is really easy to delegate authentication responsibilities to a gateway service, which acts as a secure gateway to the spark master. This could be done trivially using Nginx to provide basic authentication, or hook into a JWT enabled service for RBAC ect.
2. To be fully flexible enough to meet everyones requirements we would risk bloat of code that is mostly not required. In this implementation I've tried to keep things open for easy extension in the future - I'm still of the view that providing at least one mechanism out of the box would be nice-to-have, but my initial point trumps this feeling.
3. The additional maintenance burden of authentication is one that is unnecessary, this allows a mode where we remove that responsibility from spark and let users bring something tailored to it to the party. 

### Does this PR introduce _any_ user-facing change?

Maybe, but certainly no breaking change. By default we select the mode `None` which provides no change. However, new options are doc'd/public scope so that a user can easily toggle the secure gateway mode on. If an unsupported mode is provided, we warn and default to None opposed to throwing a critical error/handling this via require.

### How was this patch tested?
I could not see unit tests specifically covering the private scoped artefacts relating to the master, I've attempted to add basic coverage of the added utilities but could not determine how to cover the integration point with the master without massively restructuring code in ways that would arguably be breaking/changing the API. This has been tested manually.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
